### PR TITLE
add cardano-devnet submodule

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -43,6 +43,10 @@ if [[ $GURU_ENV_LOADED != true ]]; then
   source_env "$PROJECT_ROOT/cardano-cli-guru"
 fi
 
+if [[ $DEVNET_ENV_LOADED != true ]]; then
+  source_env "$PROJECT_ROOT/cardano-devnet"
+fi
+
 #### .ENV CONFIG ####
 
 # Create .env file with default environment variables if absent:

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "cardano-cli-guru"]
 	path = cardano-cli-guru
 	url = https://github.com/iburzynski/cardano-cli-guru
+[submodule "cardano-devnet"]
+	path = cardano-devnet
+	url = https://github.com/cryptophonic/cardano-devnet.git


### PR DESCRIPTION
This commit adds a new submodule "cardano-devnet" that works with jambhala in the same way cardano-cli-guru does.  It sets up the scripts path and uses $PROJECT_ROOT to copy the faucet keys into the assets directory in jambhala.  There's a basic set of instructions in the README, to be added to.